### PR TITLE
Integration now is called 'Grohe Smarthome' instead of 'Grohe Sense'

### DIFF
--- a/custom_components/grohe_smarthome/config_flow.py
+++ b/custom_components/grohe_smarthome/config_flow.py
@@ -20,10 +20,10 @@ class GroheSenseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
 
         if user_input is not None:
-            await self.async_set_unique_id('GroheSense')
+            await self.async_set_unique_id('GroheSmarthome')
             self._abort_if_unique_id_configured()
 
-            return self.async_create_entry(title='Grohe Sense', data=user_input)
+            return self.async_create_entry(title='Grohe Smarthome', data=user_input)
 
         return self.async_show_form(
             step_id="user",


### PR DESCRIPTION
This was a request from: #12 

Integration now will be visible like this:
![image](https://github.com/user-attachments/assets/33639c9c-8a44-42c7-b2e1-4ce2a248c01c)

:bangbang: 
For this to work you must delete and authenticate again
