### PR TITLE
Fix exponential data growth on total water consumption sensor

### DIFF
--- a/custom_components/grohe_smarthome/config/config.yaml
+++ b/custom_components/grohe_smarthome/config/config.yaml
@@ -70,7 +70,7 @@ devices:
         - name: 'Total water consumption'
           keypath: 'total_water_consumption'
           device_class: 'Water'
-          state_class: 'Total'
+          state_class: 'Total Increasing'
           unit: 'Liters'
         - name: 'Average daily consumption'
           keypath: 'details.data_latest.average_daily_consumption'

--- a/custom_components/grohe_smarthome/entities/entity/sensor.py
+++ b/custom_components/grohe_smarthome/entities/entity/sensor.py
@@ -118,6 +118,12 @@ class Sensor(CoordinatorEntity, SensorEntity):
         if self._coordinator is not None and self._coordinator.data is not None and self._sensor.keypath is not None:
             # We do have some data here, so let's extract it
             value = self._get_value(self._coordinator.data)
+            
+            # Ignore 0 or None for Total water consumption to prevent massive spikes when API fails
+            if self._sensor.name == 'Total water consumption' and (value == 0 or value is None):
+                _LOGGER.warning(f'Device {self._device.name} returned 0 or None for {self._sensor.name}. Ignoring to prevent data spikes.')
+                return
+
             _LOGGER.debug(
                 f'Device: {self._device.name} ({self._device.appliance_id}) with sensor name: "{self._sensor.name}" has the following value on keypath "{self._sensor.keypath}": {value}')
 


### PR DESCRIPTION
This PR fixes a bug where temporary API failures returning 0 or None cause the total water consumption sensor to spike when the actual value returns. It ignores these erroneous values and correctly configures the state class as Total Increasing.